### PR TITLE
Oneshot improved

### DIFF
--- a/ernierasta/oneshot.c
+++ b/ernierasta/oneshot.c
@@ -66,7 +66,7 @@ void update_oneshot(
                         unregister_code(mod);
                     }
                 } else {
-                    if (*state != os_down_one_used) {
+                    if (*state == os_up_queued) {
                         *state = os_down_one_used;
                     }
                 }

--- a/ernierasta/oneshot.c
+++ b/ernierasta/oneshot.c
@@ -23,7 +23,7 @@ void update_oneshot(
             }
             
             if (is_oneshot_cancel_key(keycode) && *state == os_up_queued) {
-                // Cancel oneshot on designated cancel keydown.
+                // Cancel oneshot if keycode is used as cancel key (second tap will cancel)
                 *state = os_up_unqueued;
                 if (isLayerSwitch) {
                     layer_off(mod); 
@@ -31,7 +31,6 @@ void update_oneshot(
                     unregister_code(mod);
                 }
             }
-
         } else {
             // Trigger keyup
             switch (*state) {
@@ -54,13 +53,22 @@ void update_oneshot(
         }
     } else {
         if (record->event.pressed) {
-            if (is_oneshot_cancel_key(keycode) && *state != os_up_unqueued) {
-                // Cancel oneshot on designated cancel keydown.
-                *state = os_up_unqueued;
-                if (isLayerSwitch) {
-                    layer_off(mod);
+            if (*state != os_up_unqueued) {
+                if (is_oneshot_cancel_key(keycode) || *state == os_down_one_used) {
+                    // Cancel oneshot on designated cancel keydown.
+                    // Also cancel immediately before second keydown is registered,
+                    // this prevents triggering mod (or layer) if more keys are down
+                    // before first key is up.
+                    *state = os_up_unqueued;
+                    if (isLayerSwitch) {
+                        layer_off(mod);
+                    } else {
+                        unregister_code(mod);
+                    }
                 } else {
-                    unregister_code(mod);
+                    if (*state != os_down_one_used) {
+                        *state = os_down_one_used;
+                    }
                 }
             }
         } else {

--- a/ernierasta/oneshot.h
+++ b/ernierasta/oneshot.h
@@ -7,6 +7,7 @@ typedef enum {
     os_up_unqueued,
     os_up_queued,
     os_down_unused,
+    os_down_one_used,
     os_down_used,
 } oneshot_state;
 


### PR DESCRIPTION
Fixed oneshot mechanism. Previous iteration has a problem, that second/third keydown also triggered if first key was still active, it leads to mistakes like "TEst". Holding key will still behave as normal mod, so multiple characters could be modded.